### PR TITLE
Reduce tail timeout in hello world notebook

### DIFF
--- a/examples/hello-world/hello_world.py
+++ b/examples/hello-world/hello_world.py
@@ -53,7 +53,7 @@ tell_renode('machine EnableProfiler @metrics.dump')
 tell_renode('s')
 while not os.path.exists('renode/uart.dump'):
   time.sleep(1) #waits for creating uart.dump
-!timeout 60 tail -c+2 -f renode/uart.dump | sed '/^1$/ q'
+!timeout 10 tail -c+2 -f renode/uart.dump | sed '/^1$/ q'
 tell_renode('q')
 expect_cli('Renode is quitting')
 time.sleep(1) #wait not to kill Renode forcefully

--- a/examples/hello-world/hello_world.py
+++ b/examples/hello-world/hello_world.py
@@ -53,7 +53,7 @@ tell_renode('machine EnableProfiler @metrics.dump')
 tell_renode('s')
 while not os.path.exists('renode/uart.dump'):
   time.sleep(1) #waits for creating uart.dump
-!timeout 10 tail -c+2 -f renode/uart.dump | sed '/^1$/ q'
+!timeout 10 tail -c+2 -f renode/uart.dump
 tell_renode('q')
 expect_cli('Renode is quitting')
 time.sleep(1) #wait not to kill Renode forcefully


### PR DESCRIPTION
It seems that colab can't display a graph with large data, so we had a problem with our peripherals graph.
Reported issue found: https://github.com/googlecolab/colabtools/issues/471
Reducing tail timeout decreases data in dump file and solves that issue.