### PR TITLE
Rename artifacts to avoid overriding files

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Upload magic-wand artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: magic_wand_artifacts
+          name: magic_wand_artifacts_bumped_zephyr
           path: |
             artifacts/binaries/magic_wand/*
 
@@ -143,6 +143,6 @@ jobs:
       - name: Upload hello-world artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: hello_world_artifacts
+          name: hello_world_artifacts_bumped_zephyr
           path: |
             artifacts/binaries/hello_world/*


### PR DESCRIPTION
Right now two jobs that test different Zephyr versions upload artifacts with the same names which causes some files to be overriden. This renames artifacts for job that tests bumped Zephyr so it will not override stock Zephyr binaries anymore.