### PR TITLE
Fix `test-bumped-zephyr` action

### DIFF
--- a/.github/scripts/bump_zephyr.sh
+++ b/.github/scripts/bump_zephyr.sh
@@ -13,10 +13,16 @@ BUMP_ZEPHYR_TF_MD5="ZEPHYR_MD5 := \"${BUMP_ZEPHYR_MD5}\""
 sed -i "s@^ZEPHYR_URL :=.*@${BUMP_ZEPHYR_TF_URL}@" tflite-micro/tensorflow/lite/micro/tools/make/third_party_downloads.inc
 sed -i "s@^ZEPHYR_MD5 :=.*@${BUMP_ZEPHYR_TF_MD5}@" tflite-micro/tensorflow/lite/micro/tools/make/third_party_downloads.inc
 
-ZEPHYR_SDK_RELEASES_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download"
-ZEPHYR_SDK_VERSION="v0.12.4"
-ZEPHYR_SDK_FILENAME="zephyr-sdk-0.12.4-x86_64-linux-setup.run"
+# Finding latest release of the zephyr-sdk. See https://docs.github.com/en/rest/reference/repos#releases for details
+RELEASES_JSON=`curl https://api.github.com/repos/zephyrproject-rtos/sdk-ng/releases 2>/dev/null`
+SDK_VERSION=`echo "${RELEASES_JSON}" |grep 'tag_name' | head --lines 1 | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+'`
+if [ -z $SDK_VERSION]; then
+    echo Failed to get latest SDK version && exit 1
+fi;
 
-sed -i "s@^wget ${ZEPHYR_SDK_RELEASES_URL}.*@wget ${ZEPHYR_SDK_RELEASES_URL}/${ZEPHYR_SDK_VERSION}/${ZEPHYR_SDK_FILENAME}@" install_dependencies.sh
+ZEPHYR_SDK_RELEASES_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download"
+ZEPHYR_SDK_FILENAME="zephyr-sdk-${SDK_VERSION}-x86_64-linux-setup.run"
+
+sed -i "s@^wget ${ZEPHYR_SDK_RELEASES_URL}.*@wget ${ZEPHYR_SDK_RELEASES_URL}/v${SDK_VERSION}/${ZEPHYR_SDK_FILENAME}@" install_dependencies.sh
 sed -i "s@^chmod +x.*@chmod +x ${ZEPHYR_SDK_FILENAME}@" install_dependencies.sh
 sed -i "s@^\./.*@./${ZEPHYR_SDK_FILENAME} -- -y -d \$ZEPHYR_SDK_INSTALL_DIR@" install_dependencies.sh

--- a/.github/scripts/bump_zephyr.sh
+++ b/.github/scripts/bump_zephyr.sh
@@ -21,7 +21,7 @@ if [ -z $SDK_VERSION]; then
 fi;
 
 ZEPHYR_SDK_RELEASES_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download"
-ZEPHYR_SDK_FILENAME="zephyr-sdk-${SDK_VERSION}-x86_64-linux-setup.run"
+ZEPHYR_SDK_FILENAME="zephyr-sdk-${SDK_VERSION}-linux-x86_64-setup.run"
 
 sed -i "s@^wget ${ZEPHYR_SDK_RELEASES_URL}.*@wget ${ZEPHYR_SDK_RELEASES_URL}/v${SDK_VERSION}/${ZEPHYR_SDK_FILENAME}@" install_dependencies.sh
 sed -i "s@^chmod +x.*@chmod +x ${ZEPHYR_SDK_FILENAME}@" install_dependencies.sh

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,5 +1,5 @@
 sudo apt update && sudo apt install -y cmake ninja-build gperf ccache dfu-util device-tree-compiler wget python python3-pip python3-setuptools python3-tk python3-wheel xz-utils file make gcc gcc-multilib locales tar curl unzip xxd
-pip install --upgrade cmake virtualenv
+pip install --upgrade cmake virtualenv pillow
 wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.2/zephyr-sdk-0.11.2-setup.run
 chmod +x zephyr-sdk-0.11.2-setup.run
 ./zephyr-sdk-0.11.2-setup.run -- -y -d $ZEPHYR_SDK_INSTALL_DIR


### PR DESCRIPTION
This fixes problems with zephyr-sdk not being bumped when testing latest master