### PR TITLE
Fix `hello_world` tests

### DIFF
--- a/examples/hello-world/hello_world.robot
+++ b/examples/hello-world/hello_world.robot
@@ -23,5 +23,5 @@ Should Print Brightness Sequence
     Start Emulation
 
     Wait For Line On Uart     Booting Zephyr OS
-    Wait For Line On Uart     x_value: 1.2566366*2^-2, y_value: 1.4910772*2^-2
-    Wait For Line On Uart     x_value: 1.1780966*2^2, y_value: -1.1098361*2^0
+    Wait For Line On Uart     x_value: 1.2566\\d+\\*2\\^-2, y_value: 1.4910\\d+\\*2\\^-2  treatAsRegex=true   timeout=0.1
+    Wait For Line On Uart     x_value: 1.1780\\d+\\*2\\^2, y_value: -1.1098\\d+\\*2\\^0   treatAsRegex=true   timeout=0.1


### PR DESCRIPTION
This adds regex to expected values in the hello_world robot test. Recent changes to model_data files lead to small differences in outputted `y` values (maginute of 10^-6), and in consequence failing the test. 
Also added timeouts to avoid wasting resources on failing builds