### PR TITLE
Fix typo and grep

### DIFF
--- a/.github/scripts/bump_zephyr.sh
+++ b/.github/scripts/bump_zephyr.sh
@@ -22,7 +22,7 @@ case "$(echo $TOOLCHAIN_VERSION | tr '.' '\n' | wc -l)" in
         SDK_VERSION=$TOOLCHAIN_VERSION.0
         ;;
     "3")
-        SDK_VERION=$TOOLCHAIN_VERSION
+        SDK_VERSION=$TOOLCHAIN_VERSION
         ;;
     *)
         echo "Unrecognized format of SDK version : $TOOLCHAIN_VERSION" && exit 1

--- a/.github/scripts/bump_zephyr.sh
+++ b/.github/scripts/bump_zephyr.sh
@@ -15,7 +15,7 @@ sed -i "s@^ZEPHYR_MD5 :=.*@${BUMP_ZEPHYR_TF_MD5}@" tflite-micro/tensorflow/lite/
 
 # Finding required version of the zephyr-sdk
 TOOLCHAIN_VERSION=$(curl https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/${BUMP_ZEPHYR_SHA}/cmake/verify-toolchain.cmake | \
-	grep --only-matching --extended 'TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION [0-9]+\.[0-9]+(\.[0-9]+)?' |cut -d ' ' -f 2)
+	grep --only-matching --extended --max-count=1 'TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION [0-9]+\.[0-9]+(\.[0-9]+)?' |cut -d ' ' -f 2)
 # Extend version to SemVer standard
 case "$(echo $TOOLCHAIN_VERSION | tr '.' '\n' | wc -l)" in
     "2")


### PR DESCRIPTION
This fixes typo in zephyr-sdk version selection. Also changes behaviour of grep to only take first occurence of `TOOLCHAIN_ZEPHYR_MINIMUM_REQUIRED_VERSION`.